### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests_coverage.yml
+++ b/.github/workflows/tests_coverage.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: build (Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }})


### PR DESCRIPTION
Potential fix for [https://github.com/mariofix/django-payments-chile/security/code-scanning/2](https://github.com/mariofix/django-payments-chile/security/code-scanning/2)

Add an explicit `permissions` block in `.github/workflows/tests_coverage.yml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
Best minimal fix without changing behavior: set:

- `contents: read`

This aligns with CodeQL’s recommendation and preserves current functionality for checkout/test/coverage steps while preventing unnecessary default write access.

Change location: right after the `on:` trigger block (before `jobs:`), or near the top-level keys.  
No imports, methods, or dependencies are needed (YAML workflow config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
